### PR TITLE
Search for configuration files in any active bundle.

### DIFF
--- a/src/Bundle.hpp
+++ b/src/Bundle.hpp
@@ -48,6 +48,13 @@ public:
      * containing the orogen config files.
      * */
     const std::string &getConfigurationDirectory();
+
+    /**
+     * Returns the path to the directory 
+     * containing the orogen config files.
+     * It checks all the available bundles.
+     * */
+    std::string getConfigurationPath(const std::string &task);
     
     /**
      * Returns the path to the directory 


### PR DESCRIPTION
This pull request uses the environmental variable ACTIVE_BUNDLES to search for the file in any active bundle.

Roby uses the dependencies in config/bundle.yml to search also in the bundles of which the default bundle is selected but this feature is not implemented in tools/lib_config as far as I know.

The function works also in case ACTIVE_BUNDLES is not set as it was working before (only checking the current default bundle).
