### PR TITLE
fixed unhandled case when the current folder symlink points to a not existing folder

### DIFF
--- a/src/Bundle.cpp
+++ b/src/Bundle.cpp
@@ -94,7 +94,7 @@ bool Bundle::createLogDirectory()
     const std::string currentPath(activeBundlePath + "/logs/current");
     
     //create symlink to current
-    if(boost::filesystem::exists(currentPath))
+    if(boost::filesystem::is_symlink(currentPath))
     {
         boost::filesystem::remove(currentPath);
     }


### PR DESCRIPTION
exists(..) returns false since the folder the symlink points to does not exsit.
create_directory_symlink(..) fails subsequently
is_symlink(..) returns true if the current symlink exists and false if not