### PR TITLE
Active bundles

### DIFF
--- a/src/Bundle.cpp
+++ b/src/Bundle.cpp
@@ -197,7 +197,7 @@ void Bundle::discoverDependencies(const std::string &bundle_name, std::vector<st
 
     std::vector<std::string> deps = loadDependenciesFromYAML(config_file);
     dependencies.insert(dependencies.end(), deps.begin(), deps.end());
-    for(auto d : deps)
+    for(const std::string& d : deps)
     {
         // Don't consider duplicates and avoid cyclic dependencies.
         // TODO: When we do it this way, cyclic dependencies are ignored. Better throw here?

--- a/src/Bundle.cpp
+++ b/src/Bundle.cpp
@@ -6,6 +6,7 @@
 #include <boost/lexical_cast.hpp>
 #include <iostream>
 #include <base/Time.hpp>
+#include <yaml-cpp/yaml.h>
 
 using namespace libConfig;
 
@@ -70,6 +71,12 @@ Bundle::Bundle()
     
     configDir = activeBundlePath + "/config/orogen/";
     dataDir = activeBundlePath + "/data/";
+
+    activeBundles.push_back(activeBundle);
+    discoverDependencies(activeBundle, activeBundles);
+
+    for(const std::string& b : activeBundles)
+        activeBundlePaths.push_back(findBundle(b));
 }
 
 bool Bundle::createLogDirectory()
@@ -147,25 +154,82 @@ std::string Bundle::findFile(const std::string& relativePath)
     std::string curPath = activeBundlePath + "/" + relativePath;
     if(boost::filesystem::exists(curPath))
         return curPath;
-    for(const std::string &bp: bundlePaths)
+
+    for(const std::string &path : activeBundlePaths)
     {
-        // Find it in the default bundle, in case ACTIVE_BUNDLES is not set
-        curPath = bp + "/" +activeBundle + "/" + relativePath;
+        curPath = path + "/" + relativePath;
         if(boost::filesystem::exists(curPath))
             return curPath;
-        const char *activeBundleC = getenv("ACTIVE_BUNDLES");
-        if (activeBundleC)
-        {
-            std::string selected_bundles = activeBundleC;
-            boost::char_separator<char> sep(":");
-            boost::tokenizer<boost::char_separator<char> > tokens(selected_bundles, sep);
-            for(const std::string &token : tokens)
-            {
-                curPath = bp + "/" + token + "/" + relativePath;
-                if(boost::filesystem::exists(curPath))
-                    return curPath;
-            }        
-        }
     }
     throw std::runtime_error("Bundle::findFile : Error, could not find file " + relativePath);
+}
+
+std::vector<std::string> Bundle::getConfigurationPaths(const std::string &task_model_name)
+{
+    std::string relativePath = "config/orogen/"+ task_model_name + ".yml";
+    std::vector<std::string> paths = findFiles(relativePath);
+    if(paths.empty())
+        std::runtime_error("Bundle::getConfigurationPaths: Could not find configuration file for task " + task_model_name + " in any of the active bundles");
+    return paths;
+}
+
+std::vector<std::string> Bundle::findFiles(const std::string& relativePath)
+{
+    std::vector<std::string> paths;
+    for(const std::string &path : activeBundlePaths)
+    {
+        std::string curPath = path + "/" + relativePath;
+        if(boost::filesystem::exists(curPath))
+            paths.push_back(curPath);
+    }
+    return paths;
+}
+
+void Bundle::discoverDependencies(const std::string &bundle_name, std::vector<std::string> &dependencies)
+{
+    const std::string &bundle_path = findBundle(bundle_name);
+    if(bundle_path.empty())
+        throw std::runtime_error("Bundle::discoverDependencies: Bundle " + bundle_name + " could not be found.");
+
+    const std::string &config_file = bundle_path + "/config/bundle.yml";
+    if(!boost::filesystem::exists(config_file)) // No bundle.yml file exists. We assume that this bundle has no depending bundles
+        return;
+
+    std::vector<std::string> deps = loadDependenciesFromYAML(config_file);
+    for(auto d : deps)
+    {
+        // Don't consider duplicates and avoid cyclic dependencies.
+        // TODO: When we do it this way, cyclic dependencies are ignored. Better throw here?
+        if(std::find(dependencies.begin(), dependencies.end(), d) != dependencies.end())
+            continue;
+
+        dependencies.push_back(d);
+        discoverDependencies(d, dependencies);
+    }
+}
+
+std::vector<std::string> Bundle::loadDependenciesFromYAML(const std::string &config_file)
+{
+    YAML::Node node = YAML::LoadFile(config_file);
+
+    std::vector<std::string> deps;
+    if(node["bundle"]["dependencies"])
+        deps = node["bundle"]["dependencies"].as<std::vector<std::string>>();
+
+    // Erase duplicates
+    std::set<std::string> s( deps.begin(), deps.end() );
+    deps.assign( s.begin(), s.end());
+
+    return deps;
+}
+
+std::string Bundle::findBundle(const std::string &bundle_name)
+{
+    for(const std::string &bp : bundlePaths)
+    {
+        const std::string curPath = bp + "/" + bundle_name;
+        if(boost::filesystem::is_directory(curPath))
+            return curPath;
+    }
+    return "";
 }

--- a/src/Bundle.cpp
+++ b/src/Bundle.cpp
@@ -196,6 +196,7 @@ void Bundle::discoverDependencies(const std::string &bundle_name, std::vector<st
         return;
 
     std::vector<std::string> deps = loadDependenciesFromYAML(config_file);
+    dependencies.insert(dependencies.end(), deps.begin(), deps.end());
     for(auto d : deps)
     {
         // Don't consider duplicates and avoid cyclic dependencies.
@@ -217,10 +218,13 @@ std::vector<std::string> Bundle::loadDependenciesFromYAML(const std::string &con
         deps = node["bundle"]["dependencies"].as<std::vector<std::string>>();
 
     // Erase duplicates
-    std::set<std::string> s( deps.begin(), deps.end() );
-    deps.assign( s.begin(), s.end());
+    std::vector<std::string> ret;
+    for(const std::string& d : deps){
+        if(std::find(ret.begin(), ret.end(), d) == ret.end())
+            ret.push_back(d);
+    }
 
-    return deps;
+    return ret;
 }
 
 std::string Bundle::findBundle(const std::string &bundle_name)

--- a/src/Bundle.hpp
+++ b/src/Bundle.hpp
@@ -17,6 +17,9 @@ private:
     std::string activeBundle;
     std::string activeBundlePath;
     std::vector<std::string> bundlePaths;
+
+    std::vector<std::string> activeBundles;
+    std::vector<std::string> activeBundlePaths;
     
     std::string logDir;
     std::string configDir;
@@ -61,8 +64,39 @@ public:
      * containing the data files.
      * */
     const std::string &getDataDirectory();
+
+    /**
+     * Returns the paths to all configuration files
+     * matching the given task model name. It checks
+     * all active bundles. The order of the files
+     * is the same as the order of active bundles.
+     * Throws an exception if no match is found.
+     */
+    std::vector<std::string> getConfigurationPaths(const std::string &task_model_name);
     
     std::string findFile(const std::string &relativePath);
+
+    /**
+     * Checks in all active bundles for the relative file path
+     * and returns all matches.
+     */
+    std::vector<std::string> findFiles(const std::string& relativePath);
+
+    /**
+     * Checks the bundle paths for the given bundle
+     * and returns the full path if found, empty otherwise
+     */
+    std::string findBundle(const std::string &bundle_name);
+
+    /**
+     * Find all dependencies of the given bundle. Ignores cyclic dependencies.
+     */
+    void discoverDependencies(const std::string &bundle_name, std::vector<std::string> &dependencies);
+
+    /**
+     * Load the dependencies from the given bundle config file
+     */
+    std::vector<std::string> loadDependenciesFromYAML(const std::string &config_file);
 };
 
 }//end of namespace

--- a/src/Bundle.hpp
+++ b/src/Bundle.hpp
@@ -48,20 +48,23 @@ public:
     
     /**
      * Returns the path to the directory 
+     * (in the currently selected bundle)
      * containing the orogen config files.
      * */
     const std::string &getConfigurationDirectory();
 
     /**
-     * Returns the path to the directory 
-     * containing the orogen config files.
-     * It checks all the available bundles.
+     * Returns the full path to the configuration file
+     * matching the given task model name.
+     * It checks all the active bundles,
+     * but only returns the first match. Throws
+     * and exception if no match was found.
      * */
     std::string getConfigurationPath(const std::string &task);
     
     /**
      * Returns the path to the directory 
-     * containing the data files.
+     * containing the data files in the active bundle.
      * */
     const std::string &getDataDirectory();
 
@@ -74,6 +77,10 @@ public:
      */
     std::vector<std::string> getConfigurationPaths(const std::string &task_model_name);
     
+    /**
+     * Checks in all active bundles for the relative file path
+     * and returns the first match.
+     */
     std::string findFile(const std::string &relativePath);
 
     /**


### PR DESCRIPTION
Add methods to find all configuration files in all active bundles. Up to now, it was only possible to find the first matching configuration file, which makes it impossible to use multiple bundles that contain config files of the same task model. 

Use the bundle dependency mechanism (as in orocos.rb) to find dependencies between bundles instead of the ACTIVE_BUNDLES environment variable. 

