### PR TITLE
merge individual elements when merging two ArrayconfigValues

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -128,7 +128,7 @@ bool ArrayConfigValue::merge(std::shared_ptr< ConfigValue > other)
     {
         if(i < values.size())
         {
-            values[i] = aother->values[i]->clone();
+            values[i]->merge(aother->values[i]->clone());
         }
         else
         {


### PR DESCRIPTION
@saarnold when writing cf5131144915852bbed7757960c471ee7d1b3b40, was there any reason to not include the proposed change?

This now reflects the behavior in orocos.rb  which also is more intuitive.
Example:

```
--- name:default
config:
  task_managers:
    - type: RTT
      id: artemis-control
  #For each RTT task manager described above here must follow one entry
  rtt_task_manager_configs:
    - id: artemis-control                                          #ID as mentioned above
      config:
        corba_nameserver: artemis-control            
        process_server_hostname: artemis-control               #Host name of the PC the process server 
        process_server_task_name: artemis-control_process_server   #Unique name of the task for this process server
        task_retrieval_retrials: 1000                     #Increase, if you encounter trouble starteing rock-runtime
  simulate_execution: false
  log_config: 
    whitelist: []
    blacklist: []
    log_all_ports: false
  needed_typekits: ["joint_dispatcher"]

#Start rock-runtime `rock-runtime default localhost` to execute on a different 
#computer that artemis-control
--- name:localhost
config:
  rtt_task_manager_configs:
    - id: artemis-control
      config:
        corba_nameserver: localhost
        process_server_hostname: localhost
```

Applying `default` and `localhost` keeps all the information defined for the first "rtt_task_manager_config", but just modifies the hostnames for "corba_nameserver" and "process_server_hostname".

With out the patch, the remaining properties (like "process_server_task_name") in the will be set to the c++-default values 