### PR TITLE
Fix Configuration.cpp for gcc5

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -143,8 +143,8 @@ void ArrayConfigValue::print(std::ostream &stream, int level) const
 YAML::Emitter &operator <<(YAML::Emitter &out, const ArrayConfigValue &v)
 {
     out << YAML::BeginSeq;
-    for(const std::shared_ptr<ConfigValue> &v : v.values){
-        out << v;
+    for(const std::shared_ptr<ConfigValue> &value : v.values){
+        out << value;
     }
     out << YAML::EndSeq;
     return out;


### PR DESCRIPTION
Variable v was used duplicate times (as prameter and in the loop) which seens to confuse gcc-5 on ubuntu16.04