### PR TITLE
Fix yaml-cpp linking in python binings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.0)
 find_package(Rock)
+project(lib_config VERSION 0.1)
 SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=c++11" )
 
-rock_init(lib_config 0.1)
+rock_init()
 include_directories(src)
 rock_standard_layout()
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -22,7 +22,7 @@ INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS} ${yaml-cpp_PKGC
 
 PYTHON_ADD_MODULE(bundle bundle.cpp)
 set_target_properties(bundle PROPERTIES PREFIX "")
-target_link_libraries(bundle PUBLIC
+target_link_libraries(bundle
     ${Boost_LIBRARIES}
     lib_config
     ${PYTHON_LIBRARIES}

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -18,15 +18,15 @@ message(STATUS "PYTHON_INCLUDE_DIRS = ${PYTHON_INCLUDE_DIRS}")
 message(STATUS "Boost_LIBRARIES = ${Boost_LIBRARIES}")
 message(STATUS "PYTHON_INSTALL_PATH = ${PYTHON_INSTALL_PATH}")
 
-
-INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
+INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS} ${yaml-cpp_PKGCONFIG_INCLUDE_DIRS})
 
 PYTHON_ADD_MODULE(bundle bundle.cpp)
 set_target_properties(bundle PROPERTIES PREFIX "")
-target_link_libraries(bundle
+target_link_libraries(bundle PUBLIC
     ${Boost_LIBRARIES}
     lib_config
     ${PYTHON_LIBRARIES}
+    ${yaml-cpp_PKGCONFIG_LIBRARIES}
 )
 
 add_custom_target(rockpy


### PR DESCRIPTION
This commit solves the issue, that when not the system's yaml-cpp is used the include and linking fails for the python bindings.
Moreover, the CMake Warnings have been fixed.
@maltewi 